### PR TITLE
Using DialConfig for reconnecting instead of Dial

### DIFF
--- a/rabbitmq/connection.go
+++ b/rabbitmq/connection.go
@@ -45,7 +45,7 @@ func DialConfig(url string, config amqp.Config) (*Connection, error) {
 				// wait 1s for reconnect
 				time.Sleep(ReconnectDelay)
 
-				conn, err := amqp.Dial(url)
+				conn, err := amqp.DialConfig(url, config)
 				if err != nil {
 					debugf("reconnect failed, err: %v", err)
 					continue


### PR DESCRIPTION
Spotted this while playing around with DialConfig and named connections to RabbitMQ
Also, thank you for keeping it up to date!